### PR TITLE
Remove unused props from VenueCard

### DIFF
--- a/src/components/VenueCard.tsx
+++ b/src/components/VenueCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import { MapPin } from 'lucide-react';
 
@@ -7,10 +6,9 @@ interface VenueCardProps {
   name: string;
   location: string;
   slug: string;
-  logoUrl: string;
 }
 
-const VenueCard: React.FC<VenueCardProps> = ({ name, location, slug, logoUrl }) => {
+const VenueCard: React.FC<VenueCardProps> = ({ name, location, slug }) => {
   const navigate = useNavigate();
 
   const handleCardClick = () => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -94,7 +94,6 @@ const HomePage: React.FC = () => {
                 name={venue.name}
                 location={venue.location}
                 slug={venue.slug}
-                logoUrl={venue.logoUrl}
               />
             </div>
           ))}


### PR DESCRIPTION
## Summary
- trim `logoUrl` prop and unused `Link` import from `VenueCard`
- stop passing `logoUrl` when rendering `VenueCard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687e599d638c8324a00df002e762bc91